### PR TITLE
Basic desktop CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Modules have all the same structure with a module-specific `value` definition.
 | Command | Description |
 | ------- | ----------- |
 | `npm install` | Installs dependencies |
-| `npm run dev` | Serve with hot reload at localhost:8080 |
+| `npm run serve` | Serve with hot reload at localhost:8080 |
 | `npm run build` | Build for production with minification |
 | `npm run build --report` | Build for production and view the bundle analyzer report |
 | `npm run unit` | Run unit tests |

--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -276,7 +276,7 @@
     max-width: var(--app-mobile-max-size);
     margin: 0 auto;
 
-    @media (--min-desktop-viewport) {
+    @media (--max-mobile-viewport) {
       max-width: var(--app-desktop-max-width);
     }
   }

--- a/src/app/intro/Intro.vue
+++ b/src/app/intro/Intro.vue
@@ -44,6 +44,8 @@
 </script>
 
 <style lang="postcss" scoped>
+  @import "../../styles/media-queries";
+
   .main-wireframe {
     display: flex;
     align-items: flex-start;
@@ -56,6 +58,8 @@
     padding-left: var(--base-gap);
     padding-right: var(--base-gap);
     padding-bottom: var(--base-gap);
+    max-width: 960px;
+    margin: 0 auto;
 
     & p {
       font-weight: 500;
@@ -68,6 +72,12 @@
     flex-wrap: wrap;
     align-items: center;
     margin-bottom: calc(var(--base-gap) * 2);
+  }
+
+  @media (--max-mobile-viewport) {
+    .intro-header > img {
+      max-width: 500px;
+    }
   }
 
   .intro-wrapper {

--- a/src/app/intro/Intro.vue
+++ b/src/app/intro/Intro.vue
@@ -58,7 +58,7 @@
     padding-left: var(--base-gap);
     padding-right: var(--base-gap);
     padding-bottom: var(--base-gap);
-    max-width: 960px;
+    max-width: var(--app-desktop-max-width);
     margin: 0 auto;
 
     & p {
@@ -76,7 +76,7 @@
 
   @media (--max-mobile-viewport) {
     .intro-header > img {
-      max-width: 500px;
+      max-width: 50%;
     }
   }
 

--- a/src/app/intro/components/Start.vue
+++ b/src/app/intro/components/Start.vue
@@ -107,6 +107,7 @@
     display: flex;
     justify-content: center;
     flex-direction: column;
+    align-items: center;
 
     & p {
       text-align: center;

--- a/src/app/plant/components/PlantHeader.vue
+++ b/src/app/plant/components/PlantHeader.vue
@@ -146,7 +146,7 @@
       --header-color: white;
     }
 
-    @media (--min-desktop-viewport) {
+    @media (--max-mobile-viewport) {
       height: 50vh;
     }
   }

--- a/src/app/plant/components/PlantTags.vue
+++ b/src/app/plant/components/PlantTags.vue
@@ -170,10 +170,6 @@
     background: transparent;
     margin-bottom: var(--tag-module-gap);
 
-    @media (--max-mobile-viewport) {
-      --tag-module-height: auto;
-    }
-
     &.edit-mode {
       position: relative;
       z-index: 1;
@@ -203,10 +199,6 @@
         padding: calc(var(--base-gap) / 2) var(--base-gap);
         left: 50%;
       }
-
-      @media (--max-mobile-viewport) {
-        margin-top: var(--base-gap);
-      }
     }
 
     & button:not(.hide-module) {
@@ -217,7 +209,7 @@
       box-shadow: none;
 
       @media (--max-mobile-viewport) {
-        height: 58px;
+        height: var(--tag-module-height);
       }
     }
   }
@@ -269,7 +261,6 @@
 
     @media (--max-mobile-viewport) {
       overflow-x: hidden;
-      margin-bottom: var(--base-gap);
     }
   }
 

--- a/src/app/plant/components/PlantTags.vue
+++ b/src/app/plant/components/PlantTags.vue
@@ -162,11 +162,17 @@
 </script>
 
 <style lang="postcss" scoped>
+  @import "../../../styles/media-queries";
+
   .plant-tags {
     --tag-module-gap: 4px;
     --tag-module-height: 64px;
     background: transparent;
     margin-bottom: var(--tag-module-gap);
+
+    @media (--max-mobile-viewport) {
+      --tag-module-height: auto;
+    }
 
     &.edit-mode {
       position: relative;
@@ -197,6 +203,10 @@
         padding: calc(var(--base-gap) / 2) var(--base-gap);
         left: 50%;
       }
+
+      @media (--max-mobile-viewport) {
+        margin-top: var(--base-gap);
+      }
     }
 
     & button:not(.hide-module) {
@@ -205,6 +215,10 @@
       display: flex;
       justify-content: center;
       box-shadow: none;
+
+      @media (--max-mobile-viewport) {
+        height: 58px;
+      }
     }
   }
 
@@ -252,6 +266,11 @@
     &:not(.show-input)::after {
       right: 0;
     }
+
+    @media (--max-mobile-viewport) {
+      overflow-x: hidden;
+      margin-bottom: var(--base-gap);
+    }
   }
 
   .tags-new {
@@ -282,6 +301,15 @@
       var(--base-gap)
       var(--base-gap)
       calc(var(--base-gap) / 2);
+
+    @media (--max-mobile-viewport) {
+      overflow-x: hidden;
+      padding:
+        0
+        var(--base-gap)
+        0
+        calc(var(--base-gap) / 2);
+    }
   }
 
   .tags-list {
@@ -300,10 +328,18 @@
       flex-shrink: 0;
       margin-right: calc(var(--base-gap) / 2);
 
+      @media (--max-mobile-viewport) {
+        margin-bottom: calc(var(--base-gap) / 2);
+      }
+
       &:last-child {
         /* Workaround */
         padding-right: calc(var(--base-gap) / 2);
       }
+    }
+
+    @media (--max-mobile-viewport) {
+      flex-wrap: wrap;
     }
   }
 

--- a/src/components/AuthProviderList.vue
+++ b/src/components/AuthProviderList.vue
@@ -55,6 +55,7 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
+    flex-direction: column;
 
     & li:not(:last-child) {
       margin-bottom: var(--base-gap);


### PR DESCRIPTION
I've added some basic CSS rules to scale the mobile version better on the desktop. The homepage is quite literally just the mobile view with a max-width and horizontally aligned.

![homepage plant app](https://user-images.githubusercontent.com/9220754/50573562-8cecc380-0dd6-11e9-9277-53ff68479d09.png)


On the plant detail page the tags will stack on desktop views, and keep the horizontal scroll on the mobile view.

![desktop plant page](https://user-images.githubusercontent.com/9220754/50573531-d4bf1b00-0dd5-11e9-83e7-6a3df1c97507.png)

Editing the tags looks very similar to before, just made sure it scaled well from mobile to the desktop version. I've added a margin-top on the editing field, because I want to make better use of the newly created space on the desktop view.

![desktop editing tags](https://user-images.githubusercontent.com/9220754/50573530-d4bf1b00-0dd5-11e9-88bb-86a0f6a5a2b6.png)
